### PR TITLE
Update to monster hp evaluation

### DIFF
--- a/src/main/java/battleaimod/battleai/TurnNode.java
+++ b/src/main/java/battleaimod/battleai/TurnNode.java
@@ -472,7 +472,7 @@ public class TurnNode implements Comparable<TurnNode> {
         // If vulnerability will be present in future turns, that means we will do more damage next turn (don't bother looking too far ahead).
         Optional<PowerState> vulnerability = getPower(monster, VulnerablePower.POWER_ID);
         if (vulnerability.isPresent() && vulnerability.get().amount > 1) {
-            // Guesstimation that the extra damage from Vulnerable will wind up accounting for about 5% of the monster's total health (no clue how much it actually would be)
+            // Guesstimation that the extra damage from Vulnerable will wind up accounting for about 8% of the monster's max health next turn (no clue how much it actually would be)
             totalHealth -= monster.maxHealth*0.08;
         }
 

--- a/src/main/java/battleaimod/battleai/TurnNode.java
+++ b/src/main/java/battleaimod/battleai/TurnNode.java
@@ -473,7 +473,7 @@ public class TurnNode implements Comparable<TurnNode> {
         Optional<PowerState> vulnerability = getPower(monster, VulnerablePower.POWER_ID);
         if (vulnerability.isPresent() && vulnerability.get().amount > 1) {
             // Guesstimation that the extra damage from Vulnerable will wind up accounting for about 5% of the monster's total health (no clue how much it actually would be)
-            totalHealth -= monster.maxHealth*0.05;
+            totalHealth -= monster.maxHealth*0.08;
         }
 
         if (monsterHasPower(monster, CurlUpPower.POWER_ID)) {
@@ -481,9 +481,9 @@ public class TurnNode implements Comparable<TurnNode> {
             return totalHealth + 5;
         }
         if (monsterHasPower(monster, FlightPower.POWER_ID)) {
-            // Tentative value on the assumption that about a third of the total damage to the monster will be reduced.
-            // Will vary depending on deck of course, but this should help the AI prioritize knocking down flight.
-            return (int)(totalHealth * 1.3);
+            // Tentative value on the assumption that about one half of the total damage to the monster will be halved.
+            // Will vary depending on deck of course, but this should help the AI prioritize taking down flight.
+            return (int)(totalHealth * 1.5);
         }
         return totalHealth;
     }


### PR DESCRIPTION
Cleans up the stream work to get powers for the monster state.

Tentatively adds weighting to monster hp based on statuses like vulnerability, flight, or curl up.

The theory behind this is that, in the cases where there isn't a clear "win" state, it would be good to factor in status effects that modify a monster's effective HP. All other things being equal, routing to a state where a monster has 50 remaining HP and vulnerable would be better than a state where a monster has 45 remaining HP and no vulnerable.

There might be a concern with double-counting, as the increased/reduced damage will already naturally be included in the score for the next turn, but overall I _think_ this would help the AI prioritize paths where it sets itself up for better turns in the future, especially when it's already looked ahead as far as it's able.

Feel free to reject if you think this would be a regression/unhelpful change.